### PR TITLE
Sequence handling and tests (2)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,4 +23,5 @@ ignore =
     # Some overboard docstring checks
     D100
     D101
+    D104
     D105

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,5 +1,4 @@
 from pathlib import Path
 
-
 TEST_PATH = Path(__file__).resolve().parent
 RESOURCES_PATH = TEST_PATH / "resources"


### PR DESCRIPTION
This PR executes what is described here: https://github.com/DIAGNijmegen/rse-roadmap/issues/419#issuecomment-3244631817

In short: "D" / "Z' marked sequences are traversed and all the containing items are replaced with dummies. Tests are added to cover these.